### PR TITLE
Fix a bunch of issues in i2c_master and i2c_simple_slave

### DIFF
--- a/examples/i2c_trojan/i2c_master.v
+++ b/examples/i2c_trojan/i2c_master.v
@@ -84,7 +84,7 @@ always @(posedge clk) begin
         end
         
         START: begin
-            if(periph_scl_falling == 1) begin // wait for the scl_out to be low after the start condition
+            if(periph_sda == 0 && periph_scl_falling == 1) begin // wait for the scl_out to be low after the start condition
                 next_state <= SEND_ADDR_RW;
             end
         end
@@ -145,8 +145,16 @@ always @(posedge clk) begin
             end
         end
 
+        // We always enter DUMMY_WAIT on the rising edge of an ACK: then, once SCL goes
+        // low again, it's DUMMY_WAIT's responsibility to set up SDA so that START/STOP
+        // are able to generate their respective conditions. Then we hand over to
+        // START/STOP on the next rising edge.
+        //
+        // TODO: hang on, shouldn't the value `periph_sda` was set to in DUMMY_WAIT
+        // carry over to STOP/START? they don't set anything until halfway through the
+        // high part of the clock
         DUMMY_WAIT: begin
-            if (periph_scl_falling == 1) begin // wait for scl_out to be low
+            if (periph_scl_rising == 1) begin // wait for scl_out to be low
                 if (rw == 1 && dummy_write == 1) begin
                     next_state <= START; // regen start for read.
                 end else begin
@@ -195,19 +203,10 @@ always @(posedge clk) begin
     error <= 0;
     case (state)
         IDLE: begin
-            // do nothing
+            dummy_write <= 1;
         end
 
         START: begin
-            if (periph_scl_rising == 1) begin
-                // determine whether we are in dummy write.
-                if (dummy_write == 0 && rw == 1) begin
-                    dummy_write <= 1;
-                end else begin
-                    dummy_write <= 0;
-                end
-            end
-
             if (clock_counter == 25 && periph_scl == 1) begin
                 periph_sda <= 0; // initiate the start condition that sda_out goes low when scl_out remains high
             end
@@ -288,9 +287,15 @@ always @(posedge clk) begin
         DUMMY_WAIT: begin
             if (dummy_write == 1 && rw == 1) begin // if in read dummy write
                 // pull up sda as we gen start later.
+                // The slave should be holding SDA low the whole time SCL is high, so there's no
+                // risk of accidentally triggering a stop condition here.
                 periph_sda <= 1;
             end else begin
                 periph_sda <= 0;
+            end
+
+            if (periph_scl_rising == 1) begin
+                dummy_write <= 0;
             end
         end
 

--- a/examples/i2c_trojan/i2c_simple_slave.v
+++ b/examples/i2c_trojan/i2c_simple_slave.v
@@ -127,6 +127,18 @@ always@(posedge clk ) begin
     end
 end
 
+// This register stores whether the host returned a NAK for our last TX.
+reg i2c_nak;
+wire i2c_nak_clr;
+wire i2c_nak_en;
+always @(posedge clk) begin
+    if (~rst_n || i2c_nak_clr) begin
+        i2c_nak <= 0;
+    end else if (i2c_nak_en) begin
+        i2c_nak <= sda_di_reg;
+    end
+end
+
 localparam  S_IDLE      = 4'h0, 
             S_START     = 4'h1, 
             S_ADDR_RX   = 4'h2,
@@ -134,13 +146,11 @@ localparam  S_IDLE      = 4'h0,
 
             S_STALL  = 4'h4,
 
-            S_DATA_WAIT = 4'h5, 
+            S_DATA_RX       = 4'h5,
+            S_DATA_RX_ACK   = 4'h6,
 
-            S_DATA_RX       = 4'h6,
-            S_DATA_RX_ACK   = 4'h7,
-
-            S_DATA_TX      = 4'h8,
-            S_DATA_TX_ACK  = 4'h9,
+            S_DATA_TX      = 4'h7,
+            S_DATA_TX_ACK  = 4'h8,
 
             S_ERROR     = 4'hD,
             S_IGNORE    = 4'hE,
@@ -173,8 +183,9 @@ always@* begin
     i2c_buf_tx_shift_en <= 0;
     i2c_buf_cnt_clr <= 0;
     i2c_buf_cnt_en <= 0;
+    i2c_nak_clr <= 0;
+    i2c_nak_en <= 0;
 
-    i2c_addr_rw_valid_stb <= 0;
     i2c_data_tx_loaded_stb <= 0;
     i2c_data_tx_done_stb <= 0;
     i2c_error_stb <= 0;
@@ -192,6 +203,7 @@ case(state)
             next_state <= S_IDLE;
     end
     S_START: begin //now wait for SCL to go low to join SDA
+        i2c_nak_clr <= 1;
         if(sda_di_reg == 0 && scl_di_reg == 0) begin
             next_state <= S_ADDR_RX;
             i2c_buf_clr <= 1;
@@ -237,17 +249,6 @@ case(state)
         end else begin
             i2c_clock_stretch <= 1; //we'll always stall at least 1 clock cycle 
                                     //  for stability reasons
-            next_state <= S_DATA_WAIT;
-        end
-    end
-    
-    S_DATA_WAIT: begin
-        //wait for the next sda falling edge before going to tx/rx as needed
-        //(it is however possible to have a re-start)
-        if(sda_falling_edge == 1 && scl_di_reg == 1) begin
-            //restart condition
-            next_state <= S_START;
-        end else if(sda_di_reg == 0 && scl_di_reg == 0) begin
             if(i2c_addr_rw_reg[0] == 0) begin
                 i2c_buf_clr <= 1;
                 i2c_buf_cnt_clr <= 1;
@@ -255,11 +256,10 @@ case(state)
             end else begin
                 i2c_buf_ld_tx <= 1;
                 i2c_buf_cnt_clr <= 1;
-                i2c_data_tx_loaded_stb <= 1;
+                i2c_data_tx_loaded_stb <= ~i2c_nak;
                 next_state <= S_DATA_TX;
             end
-        end else
-            next_state <= S_DATA_WAIT;
+        end
     end
 
     S_DATA_RX: begin
@@ -297,20 +297,25 @@ case(state)
     end
 
     S_DATA_TX: begin
-        i2c_tx_en <= 1;
-        if(sda_rising_edge == 1 && scl_di_reg == 1 && i2c_buf_cnt <= 1)
+        i2c_tx_en <= ~i2c_nak;
+        // TODO: check for start conditions here too
+        if(sda_rising_edge == 1 && scl_di_reg == 1 && i2c_buf_cnt <= 1) begin
             //we're done here
             next_state <= S_DONE;
-        else if(sda_rising_edge == 1 && scl_di_reg == 1 && i2c_buf_cnt <= 1)
+        end else if(sda_rising_edge == 1 && scl_di_reg == 1 && i2c_buf_cnt <= 1) begin
             //this is an error, this shouldn't happen mid-byte
             next_state <= S_ERROR;
-        else if(scl_falling_edge == 1 && i2c_buf_cnt != 3'h7) begin
-            i2c_buf_tx_shift_en <= 1;
-            i2c_buf_cnt_en <= 1;
-            next_state <= S_DATA_TX;
-        end else if(scl_falling_edge == 1 && i2c_buf_cnt == 7) begin
-            i2c_data_tx_done_stb <= 1;
-            next_state <= S_DATA_TX_ACK;
+        end else if (scl_falling_edge == 1) begin
+            if (i2c_nak == 1)
+                next_state <= S_ERROR;
+            else if(i2c_buf_cnt != 3'h7) begin
+                i2c_buf_tx_shift_en <= 1;
+                i2c_buf_cnt_en <= 1;
+                next_state <= S_DATA_TX;
+            end else begin
+                i2c_data_tx_done_stb <= 1;
+                next_state <= S_DATA_TX_ACK;
+            end
         end else  
             next_state <= S_DATA_TX;
     end
@@ -319,8 +324,12 @@ case(state)
         //unlike with the RX_ACK, the ACK actually comes from the master
         if(scl_falling_edge) 
             next_state <= S_STALL;
-        else
+        else begin
+            if (scl_rising_edge == 1) begin
+                i2c_nak_en <= 1;
+            end
             next_state <= S_DATA_TX_ACK;
+        end
     end
 
     S_IGNORE: begin
@@ -343,7 +352,7 @@ endcase
 end
 
 assign scl_pulldown = 0 | i2c_clock_stretch;
-assign sda_pulldown = 0 | i2c_ack | (i2c_tx_en ? i2c_buf[7] : 0);
+assign sda_pulldown = 0 | i2c_ack | (i2c_tx_en ? ~i2c_buf[7] : 0);
 
 
 


### PR DESCRIPTION
I debugged and fixed a lot of issues in these while working on lab 3 - there are still some TODOs but I want other people to be able to use this already.

List of bugs fixed:
- Made `i2c_simple_slave` respect NAKs: previously it seemed to expect the host to send it a stop condition after a regular ACK, despite the fact that it might be holding SDA low at that point and preventing itself from noticing that.
- Fixed `i2c_addr_rw_valid_stb` being set in two different places; I think the second instance always setting it to 0 might have overridden the first, causing it to never activate?
- Removed `S_DATA_WAIT`: I'm not really sure what its purpose was, and its check for transitioning into `S_DATA_RX` or `S_DATA_TX` could cause the FSM to get stuck in `S_DATA_WAIT` state forever, or much longer than it should.
  - I think the concrete issue this caused was that if you performed a clock stretch before transmitting, SDA would no longer be low (since you're the one in charge of setting it), causing the check to never fire. Ordinarily it only works because SDA hasn't had time to go high after the ACK yet.
- All bits transmitted by `i2c_simple_slave` were inverted, since they were connected directly to the pulldown signal.
- If `start` happened to be asserted between the middle of SCL being high and the falling edge, `i2c_master` wouldn't generate a start condition.
- If `start` happened to be asserted while SCL was high, `dummy_write` would not be toggled.
- Both `state` and `next_state` were assigned to synchronously in `i2c_master`'s FSM, meaning that the next state was being calculated based on outdated information.
  - After my fix to `dummy_write`, this meant that the code which was intended to set it to 0 on the same cycle as the FSM switched to `START`/`STOP` state would end up running a cycle too early, and then causing SDA to be set to 0 and preventing a restart condition from being generated.