### PR TITLE
Fix make visualize command

### DIFF
--- a/examples/hackster.mk
+++ b/examples/hackster.mk
@@ -129,7 +129,7 @@ program_power: $(BITSTREAM)
 	$(PROGRAMMER) p $(BITSTREAM) $(FPGA_PORT) power_data.txt $(NUM_CAPTURE_POWER_BLOCKS)
 
 $(SYNTH_OUT).svg: $(SYNTH_SOURCES)
-	$(SYNTH) -p "read -sv $(SYNTH_SOURCES); hierarchy -top $(SYNTH_TOP_MODULE); proc; opt; show -format svg -viewer none -prefix $(SYNTH_OUT); write_json simple.$(SYNTH_OUT)"
+	$(SYNTH) -p "read -sv $(SYNTH_SOURCES); hierarchy -top $(SYNTH_TOP_MODULE); proc; opt; show -format svg -viewer none -prefix $(SYNTH_OUT) $(SYNTH_TOP_MODULE); write_json simple.$(SYNTH_OUT)"
 
 
 # ==============================================================================


### PR DESCRIPTION
The `make visualize` command is not working because there is no part selected to visualize. Hence, Yosys always returned the following error:
```
ERROR: For formats different than 'ps' or 'dot' only one module must be selected.
```

This pull request adds `$(SYNTH_TOP_MODULE)` as the selected part to visualize. The command now ended successfully and resulting an SVG image.